### PR TITLE
Minor edit to remove redundant word in Preface

### DIFF
--- a/body.tex
+++ b/body.tex
@@ -43,7 +43,7 @@ software system Sage (\url{http://www.sagemath.org}), and the reader
 should try every such example and experiment with similar examples.
 
 \vspace{1.5ex}\noindent{}{\bf Background.}  The reader should know how
-to read and write mathematical proofs and must have know the basics of
+to read and write mathematical proofs and must know the basics of
 groups, rings, and fields.  Thus, the prerequisites for this book are
 more than the prerequisites for most elementary number theory books,
 while still being aimed at undergraduates.


### PR DESCRIPTION
The sentence "The reader should know how to read and write mathematical proofs and must have know the basics of groups, rings, and fields" seems to have a redundant word.

I have removed the word "have" so the sentence becomes "The reader should know how to read and write mathematical proofs and must know the basics of groups, rings, and fields"
