### PR TITLE
Fix typo in set of odd numbers

### DIFF
--- a/body.tex
+++ b/body.tex
@@ -869,7 +869,7 @@ Go to Step~\ref{alg:sieve_2}.
 \end{algorithm}
 For example, to list the primes $\leq 40$ using the sieve, we
 proceed as follows.  First $P=[2]$ and
-$$X = [3,5,7,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39].$$
+$$X = [3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39].$$
 We append $3$ to $P$ and cross off all multiples of $3$ to obtain
 the new list
 $$X = [5,7,11,13,17,19,23,25,29,31,35,37].$$


### PR DESCRIPTION
Typo in the listed set X of all odd numbers less than 40. The missing odd integer being 9